### PR TITLE
add max supported bots

### DIFF
--- a/src/control.lua
+++ b/src/control.lua
@@ -1,7 +1,7 @@
 script.on_event(defines.events.on_player_created, function(event)
 	local player = game.players[event.player_index]
 	
-	player.insert{name = "construction-robot", count = 20}
+	player.insert{name = "construction-robot", count = 40}
 	player.insert{name = "power-armor", count = 1}
 	player.insert{name = "personal-roboport-equipment", count = 4}
 	player.insert{name = "fusion-reactor-equipment", count = 1}


### PR DESCRIPTION
Change number of construction robots to max supported by 4 roboports - that is 40.